### PR TITLE
enhance hg pushlog with link to buglist on bugzilla 

### DIFF
--- a/buglist-link.js
+++ b/buglist-link.js
@@ -1,37 +1,37 @@
-var bugs = [];
-
 function createBuglist() {
+	const bugs = new Set();
+	const titlebar = document.querySelector('div.title');
+	
+	if (!titlebar) {
+		return
+	}
+	titlebar.style = 'overflow:auto';
+
 	//look for Bug # on page
 	let result;
 	let re = /Bug ([0-9]+)/ig;
 	while ((result = re.exec(document.body.innerText)) !== null) {
-		bugs.push(result[1]);
+		bugs.add(result[1]);
 	}
-	//consolidate Bug #
-	bugs = new Set(bugs);
 
 	if (bugs.size === 0) {
 		return;
 	}
 
-	var title = document.getElementsByClassName('title');
-	var titlebar = title[0];
-	titlebar.style = 'overflow:auto';
+	//generate url for buglist link
+	let url = 'https://bugzilla.mozilla.org/buglist.cgi?bug_id=';
+	bugs.forEach(bug => {
+		url += bug + ',';
+	});
 
+	//create buglist link
 	let a = document.createElement('a');
 	a.textContent = 'View as Buglist on Bugzilla';
-	a.href = 'https://bugzilla.mozilla.org/buglist.cgi?bug_id=';
+	a.href = url;
 	a.id = 'addon-buglist';
 	a.style = 'float:right';
 
-	//create generic buglist-link
 	titlebar.appendChild(a);
-
-	//fill link to buglist with data
-	for (let bug of bugs) {
-		let a = document.getElementById('addon-buglist');
-		a.href += bug + ",";
-	}
 }
 
 createBuglist();

--- a/buglist-link.js
+++ b/buglist-link.js
@@ -1,0 +1,37 @@
+var bugs = [];
+
+function getCommonLandings() {
+	//look for Bug # on page
+	let result;
+	let re = /Bug ([0-9]+)/ig;
+	while ((result = re.exec(document.body.innerText)) !== null) {
+		bugs.push(result[1]);
+	}
+	//consolidate Bug #
+	bugs = new Set(bugs);
+	
+	if (bugs.size === 0) {
+		return;
+	}
+
+	var title = document.getElementsByClassName('title');
+	var titlebar = title[0];
+	titlebar.style = 'overflow:auto';
+
+	let a = document.createElement('a');
+	a.textContent = 'View as Buglist on Bugzilla';
+	a.href = 'https://bugzilla.mozilla.org/buglist.cgi?bug_id=';
+	a.id = 'addon-buglist';
+	a.style = 'float:right';
+
+	//create link to buglist
+	titlebar.appendChild(a);
+	
+	//fill link to buglist with data
+	for (let bug of bugs) {
+		let a = document.getElementById('addon-buglist');
+		a.href += bug + ",";
+	}
+}
+
+getCommonLandings();

--- a/buglist-link.js
+++ b/buglist-link.js
@@ -26,7 +26,7 @@ function createBuglist() {
 
 	//create buglist link
 	let a = document.createElement('a');
-	a.textContent = 'View as Buglist on Bugzilla';
+	a.textContent = 'View as buglist on Bugzilla';
 	a.href = url;
 	a.id = 'addon-buglist';
 	a.style = 'float:right';

--- a/buglist-link.js
+++ b/buglist-link.js
@@ -1,6 +1,6 @@
 var bugs = [];
 
-function getCommonLandings() {
+function createBuglist() {
 	//look for Bug # on page
 	let result;
 	let re = /Bug ([0-9]+)/ig;
@@ -9,7 +9,7 @@ function getCommonLandings() {
 	}
 	//consolidate Bug #
 	bugs = new Set(bugs);
-	
+
 	if (bugs.size === 0) {
 		return;
 	}
@@ -24,9 +24,9 @@ function getCommonLandings() {
 	a.id = 'addon-buglist';
 	a.style = 'float:right';
 
-	//create link to buglist
+	//create generic buglist-link
 	titlebar.appendChild(a);
-	
+
 	//fill link to buglist with data
 	for (let bug of bugs) {
 		let a = document.getElementById('addon-buglist');
@@ -34,4 +34,4 @@ function getCommonLandings() {
 	}
 }
 
-getCommonLandings();
+createBuglist();

--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,11 @@
                         "https://hg.mozilla.org/*"],
             "js": ["content.js"],
             "run_at": "document_end"
+        },
+        {
+            "matches": ["https://hg.mozilla.org/mozilla-central/pushloghtml*"],
+            "js": ["buglist-link.js"],
+			"run_at": "document_end"
         }
     ],
     "permissions": [

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,7 @@
             "run_at": "document_end"
         },
         {
-            "matches": ["https://hg.mozilla.org/mozilla-central/pushloghtml*"],
+            "matches": ["https://hg.mozilla.org/*/pushloghtml?*"],
             "js": ["buglist-link.js"],
 			"run_at": "document_end"
         }


### PR DESCRIPTION
this is a proposal for an enhancement for the addon.
it would add a link to the top right of a hg pushlog url providing a link to bugzilla with the list of bugs that get mentioned in that range of patches (on bugzilla you'd then have the benefit of sorting by component, author of the patch or further filtering...)