### PR TITLE
Update pushlog-addon to use buildhub2 (#7)

### DIFF
--- a/content.js
+++ b/content.js
@@ -118,7 +118,7 @@ function getPushlogUrl(last, prev, channel) {
 }
 
 async function getBuildInfo(buildid) {
-  const url = "https://buildhub.prod.mozaws.net/v1/buckets/build-hub/collections/releases/search";
+  const url = "https://buildhub.moz.tools/api/search";
   const query = {
     "aggs": {
       "products": {

--- a/manifest.json
+++ b/manifest.json
@@ -32,7 +32,7 @@
         }
     ],
     "permissions": [
-        "https://buildhub.prod.mozaws.net/*",
+        "https://buildhub.moz.tools/*",
         "contextMenus",
         "tabs"
     ]


### PR DESCRIPTION
I tested it out as a temporary extension. It does add the pushlog menu item and that goes to a push log. I think this is right, but I've never used it before, so I'm not positive.

Fixes #7.